### PR TITLE
fix: harden PAN-OS configuration actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.7
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2014-2025 Splunk Inc.
+   Copyright (c) 2014-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Palo Alto Networks Firewall
-Copyright (c) 2014-2025 Splunk Inc.
+Copyright (c) 2014-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Palo Alto Networks Firewall
 
-Publisher: Splunk \
-Connector Version: 2.1.4 \
-Product Vendor: Palo Alto Networks \
-Product Name: Firewall \
+Publisher: Splunk <br>
+Connector Version: 2.1.4 <br>
+Product Vendor: Palo Alto Networks <br>
+Product Name: Firewall <br>
 Minimum Product Version: 5.3.3
 
 This app integrates with the Palo Alto Networks Firewall to support containment and investigative actions
@@ -39,20 +39,20 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity \
-[block url](#action-block-url) - Block an URL \
-[unblock url](#action-unblock-url) - Unblock an URL \
-[block application](#action-block-application) - Block an application \
-[unblock application](#action-unblock-application) - Unblock an application \
-[block ip](#action-block-ip) - Block an IP \
-[unblock ip](#action-unblock-ip) - Unblock an IP \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity <br>
+[block url](#action-block-url) - Block an URL <br>
+[unblock url](#action-unblock-url) - Unblock an URL <br>
+[block application](#action-block-application) - Block an application <br>
+[unblock application](#action-unblock-application) - Unblock an application <br>
+[block ip](#action-block-ip) - Block an IP <br>
+[unblock ip](#action-unblock-ip) - Unblock an IP <br>
 [list applications](#action-list-applications) - List the applications that the device knows about and can block. If the action parameter 'vsys' is not specified then 'vsys1' is used by default
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -67,7 +67,7 @@ No Output
 
 Block an URL
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action does the following to block an URL:<ul><li>Create an URL category object named <b>Phantom URL Category</b>, if not found.</li><li>Add the URL to block to this category.</li><li>Create an URL Filtering profile object named <b>Phantom URL List</b>, if not found.</li><li>Add the Phantom URL Category to this profile.</li><li>Re-Configure the policy <b>Phantom URL Security Policy</b> to use the created URL Filtering profile.<br>The policy is created if not found.</li><li>Move the policy above the <b>sec_policy</b> if specified, else move it before the first detected <i>allow</i> policy.</li><li>The action then proceeds to <b>commit</b> the changes.</li></ul>NOTE: Multiple <b>block url</b> actions will <i>not</i> result in multiple categories/policies.<br>The <b>Phantom URL Security Policy</b> policy is created with the following properties:<br><ul><li>from: any</li><li>to: any</li><li>source: any</li><li>destination: any</li><li>source-user: any</li><li>category: any</li><li>service: application-default</li><li>hip-profiles: any / source-hip: any, destination-hip: any</li><li>description: Created by Phantom, please don't edit</li><li>action: allow</li><li>application: any</li></ul>.
@@ -99,7 +99,7 @@ action_result.parameter.ph | ph | | |
 
 Unblock an URL
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action removes the URL from the <b>Phantom URL Category</b> object, before proceeding to <b>commit</b> the configuration.
@@ -128,7 +128,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Block an application
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action uses a multistep approach to block an application:<ul><li>Create an application group named <b>Phantom App List</b> if not found.</li>Add the application to block to this group</li><li>Configure the application group as the <i>application</i> to the policy named <b>Phantom App Security Policy</b>.<br>The policy is created if not found on the device.</li><li>The action then proceeds to <b>commit</b> the changes.</li></ul>NOTE: Multiple <b>block application</b> actions will <i>not</i> result in multiple policies or groups. Instead the same App policy and group will be updated.<br>The <b>Phantom App Security Policy</b> policy is created with the following properties:<br><ul><li>from: any</li><li>to: any</li><li>source: any</li><li>destination: any</li><li>source-user: any</li><li>category: any</li><li>service: application-default</li><li>hip-profiles: any / source-hip: any, destination-hip: any</li><li>description: Created by Phantom, please don't edit</li><li>action: deny</li><li>application: <b>Phantom App List</b></li></ul><br>If the action parameter <b>vsys</b> is not specified then <b>'vsys1'</b> is used by default.
@@ -157,7 +157,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Unblock an application
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action removes the app from the <b>Phantom App List</b> object, before proceeding to <b>commit</b> the configuration.<br>If the action parameter <b>vsys</b> is not specified then <b>'vsys1'</b> is used by default.
@@ -186,7 +186,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Block an IP
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action uses a multistep approach to block an IP. It behaves differently based upon whether <b>is_source_address</b> is true or not. By default, it is false. The approach is:<ul><li>Create an address entry with the specified IP address<li>The container id of the phantom action is added as a tag to the address entry when it's created<li>If <b>is_source_address</b> is false:<br><ul><li>add this entry to an address group called <b>Phantom Network List</b></li><li>configure the address group as a <i>destination</i> to the policy named <b>Phantom IP Security Policy</b>.<br>The <b>Phantom IP Security Policy</b> policy is created with the following properties:<br><ul><li>from: any<li>to: any<li>source: any<li>destination: <b>Phantom Network List</b><li>source-user: any<li>category: any<li>service: application-default<li>hip-profiles: any / source-hip: any, destination-hip: any<li>description: Created by Phantom, please don't edit<li>action: deny<li>application: any</ul></li></ul>If <b>is_source_address</b> is true:<br><ul><li>add this entry to an address group called <b>Phantom Network List Source</b><li>configure the address group as a <i>source</i> to the policy named <b>Phantom src IP Security Policy.</b>The <b>Phantom src IP Security Policy</b> policy is created with the following properties:<br><ul><li>from: any<li>to: any<li>source: <b>Phantom Network List Source</b><li>destination: any<li>source-user: any<li>category: any<li>service: application-default<li>hip-profiles: any / source-hip: any, destination-hip: any<li>description: Created by Phantom, please don't edit<li>action: deny<li>application: any</ul></li></ul><li>The policy is created if not found on the device.</li><li>The action then proceeds to <b>commit</b> the changes.</ul>NOTE: If the IP is of type wildcard mask, the address object is created without a tag and is directly added to the security policy. Multiple <b>block ip</b> actions will <i>not</i> result in multiple policies or groups.<br>If the action parameter <b>vsys</b> is not specified then <b>'vsys1'</b> is used by default.
@@ -217,7 +217,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Unblock an IP
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 </p>This action removes the IP from a specific Address Group depending upon whether <b>is_source_address</b> is true.  By default, it is false.</p>if <b>is_source_address</b> is false:<ul><li>This action removes the IP from the <b>Phantom Network List</b> Address Group.</li></ul>If <b>is_source_address</b> is true:<ul><li>This action removes the IP from the <b>Phantom Network Source list</b> Address Group.</li></ul><p>Afterwards, the action proceeds to <b>commit</b> the configuration.<br>If the action parameter <b>vsys</b> is not specified then <b>'vsys1'</b> is used by default.<br/> NOTE: If the IP is of type wildcard mask, the action removes the IP from the security policy.
@@ -248,7 +248,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List the applications that the device knows about and can block. If the action parameter 'vsys' is not specified then 'vsys1' is used by default
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -393,7 +393,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2014-2025 Splunk Inc.
+# Copyright (c) 2014-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/paloaltonetworksfirewall.json
+++ b/paloaltonetworksfirewall.json
@@ -19,7 +19,7 @@
     "fips_compliant": true,
     "logo": "logo_paloaltonetworks.svg",
     "logo_dark": "logo_paloaltonetworks_dark.svg",
-    "license": "Copyright (c) 2014-2025 Splunk Inc.",
+    "license": "Copyright (c) 2014-2026 Splunk Inc.",
     "configuration": {
         "device": {
             "data_type": "string",
@@ -1489,5 +1489,11 @@
             ],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/paloaltonetworksfirewall_connector.py
+++ b/paloaltonetworksfirewall_connector.py
@@ -425,10 +425,14 @@ class PanConnector(BaseConnector):
 
         result_data = result_data.pop(0)
         job_id = result_data.get("job")
+        if not job_id:
+            return action_result.set_status(phantom.APP_ERROR, "Commit response did not contain a job ID")
 
         self.debug_print(f"Commit job id: {job_id}")
 
-        while True:
+        deadline = time.monotonic() + PAN_COMMIT_MAX_WAIT_SECS
+        job = {}
+        while time.monotonic() <= deadline:
             data = {"type": "op", "key": self._key, "cmd": f"<show><jobs><id>{job_id}</id></jobs></show>"}
 
             status_action_result = ActionResult()
@@ -436,8 +440,10 @@ class PanConnector(BaseConnector):
             status = self._make_rest_call(data, status_action_result)
 
             if phantom.is_fail(status):
-                action_result.set_status(phantom.APP_SUCCESS, status_action_result.get_message())
-                return action_result.get_status()
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Failed to query commit job '{job_id}': {status_action_result.get_message()}",
+                )
 
             self.debug_print("status", status_action_result)
 
@@ -451,6 +457,25 @@ class PanConnector(BaseConnector):
             self.send_progress(PAN_PROG_COMMIT_PROGRESS, progress=job.get("progress"))
 
             time.sleep(2)
+        else:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"Commit job '{job_id}' did not finish within {PAN_COMMIT_MAX_WAIT_SECS} seconds",
+            )
+
+        job_result = job.get("result")
+        if job_result != "OK":
+            details = job.get("details")
+            if isinstance(details, dict):
+                details = details.get("line")
+            if isinstance(details, list):
+                details = ", ".join(str(item) for item in details)
+
+            message = f"Commit job '{job_id}' finished with result '{job_result}'"
+            if details:
+                message += f". Details: {details}"
+            message = message.replace("{", "{{").replace("}", "}}")
+            return action_result.set_status(phantom.APP_ERROR, message)
 
         return action_result.get_status()
 

--- a/paloaltonetworksfirewall_connector.py
+++ b/paloaltonetworksfirewall_connector.py
@@ -19,6 +19,7 @@ import ipaddress
 import json
 import re
 import time
+from xml.sax.saxutils import escape as xml_escape
 
 import phantom.app as phantom
 import requests
@@ -497,7 +498,7 @@ class PanConnector(BaseConnector):
             "action": "set",
             "key": self._key,
             "xpath": URL_CAT_XPATH.format(vsys=vsys, url_category_name=BLOCK_URL_CAT_NAME),
-            "element": URL_CAT_ELEM.format(url=block_url),
+            "element": URL_CAT_ELEM.format(url=xml_escape(block_url)),
         }
 
         status = self._make_rest_call(data, action_result)
@@ -573,7 +574,7 @@ class PanConnector(BaseConnector):
             "action": "set",
             "key": self._key,
             "xpath": APP_GRP_XPATH.format(vsys=vsys, app_group_name=BLOCK_APP_GROUP_NAME),
-            "element": APP_GRP_ELEM.format(app_name=block_app),
+            "element": APP_GRP_ELEM.format(app_name=xml_escape(block_app)),
         }
 
         status = self._make_rest_call(data, action_result)

--- a/paloaltonetworksfirewall_connector.py
+++ b/paloaltonetworksfirewall_connector.py
@@ -30,6 +30,9 @@ from paloaltonetworksfirewall_consts import *
 
 
 class PanConnector(BaseConnector):
+    _XPATH_META_RE = re.compile(r"['\"\[\]]")
+    _IP_META_CHARS = frozenset("'\"<>&|[]")
+
     def __init__(self):
         # Call the BaseConnectors init first
         super().__init__()
@@ -117,6 +120,20 @@ class PanConnector(BaseConnector):
             action_result.add_data(result)
 
         return action_result.get_status()
+
+    def _validate_action_parameters(self, param):
+        for param_name in (PAN_JSON_VSYS, PAN_JSON_URL, PAN_JSON_APPLICATION):
+            value = param.get(param_name)
+            if value is not None and (not isinstance(value, str) or self._XPATH_META_RE.search(value)):
+                return f"Invalid value for '{param_name}' parameter"
+
+        ip_value = param.get(PAN_JSON_IP)
+        if ip_value is not None and (
+            not isinstance(ip_value, str) or len(ip_value) > 255 or any(char in self._IP_META_CHARS for char in ip_value)
+        ):
+            return f"Invalid value for '{PAN_JSON_IP}' parameter"
+
+        return None
 
     def _get_key(self, action_result):
         data = {"type": "keygen", "user": self._username, "password": self._password}
@@ -851,6 +868,11 @@ class PanConnector(BaseConnector):
     def handle_action(self, param):
         result = None
         action = self.get_action_identifier()
+
+        validation_error = self._validate_action_parameters(param)
+        if validation_error:
+            action_result = self.add_action_result(ActionResult(dict(param)))
+            return action_result.set_status(phantom.APP_ERROR, validation_error)
 
         if action == phantom.ACTION_ID_TEST_ASSET_CONNECTIVITY:
             result = self._test_connectivity(param)

--- a/paloaltonetworksfirewall_connector.py
+++ b/paloaltonetworksfirewall_connector.py
@@ -29,6 +29,19 @@ from phantom.base_connector import BaseConnector
 from paloaltonetworksfirewall_consts import *
 
 
+MAX_XML_REPLY_BYTES = 10 * 1024 * 1024
+DOCTYPE_RE = re.compile(rb"<!DOCTYPE", re.IGNORECASE)
+
+
+def _safe_xml_to_dict(xml_text):
+    data = xml_text.encode("utf-8", errors="replace") if isinstance(xml_text, str) else xml_text
+    if len(data) > MAX_XML_REPLY_BYTES:
+        raise ValueError(f"XML reply exceeds the {MAX_XML_REPLY_BYTES}-byte limit")
+    if DOCTYPE_RE.search(data):
+        raise ValueError("XML reply contains a prohibited DOCTYPE declaration")
+    return xmltodict.parse(data)
+
+
 class PanConnector(BaseConnector):
     _XPATH_META_RE = re.compile(r"['\"\[\]]")
     _IP_META_CHARS = frozenset("'\"<>&|[]")
@@ -146,7 +159,7 @@ class PanConnector(BaseConnector):
 
         try:
             xml = response.text
-            response_dict = xmltodict.parse(xml)
+            response_dict = _safe_xml_to_dict(xml)
         except Exception as e:
             self.error_print(PAN_ERR_UNABLE_TO_PARSE_REPLY, e)
             return action_result.set_status(phantom.APP_ERROR, f"{PAN_ERR_UNABLE_TO_PARSE_REPLY}: {e!s}")
@@ -220,7 +233,7 @@ class PanConnector(BaseConnector):
             if hasattr(action_result, "add_debug_data"):
                 action_result.add_debug_data({"r_text": xml})
 
-            response_dict = xmltodict.parse(xml)
+            response_dict = _safe_xml_to_dict(xml)
         except Exception as e:
             self.error_print(PAN_ERR_UNABLE_TO_PARSE_REPLY, e)
             return action_result.set_status(phantom.APP_ERROR, f"{PAN_ERR_UNABLE_TO_PARSE_REPLY}: {e!s}")

--- a/paloaltonetworksfirewall_connector.py
+++ b/paloaltonetworksfirewall_connector.py
@@ -1,6 +1,6 @@
 # File: paloaltonetworksfirewall_connector.py
 #
-# Copyright (c) 2014-2025 Splunk Inc.
+# Copyright (c) 2014-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/paloaltonetworksfirewall_consts.py
+++ b/paloaltonetworksfirewall_consts.py
@@ -41,6 +41,7 @@ PAN_JSON_SEC_POLICY = "sec_policy"
 PAN_JSON_SOURCE_ADDRESS = "is_source_address"
 PAN_DEFAULT_SOURCE_ADDRESS = False
 PAN_DEFAULT_TIMEOUT = 30
+PAN_COMMIT_MAX_WAIT_SECS = 1800
 
 # Name consts
 SEC_POL_NAME = "Phantom {type} Security Policy"

--- a/paloaltonetworksfirewall_consts.py
+++ b/paloaltonetworksfirewall_consts.py
@@ -1,6 +1,6 @@
 # File: paloaltonetworksfirewall_consts.py
 #
-# Copyright (c) 2014-2025 Splunk Inc.
+# Copyright (c) 2014-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,2 @@
 **Unreleased**
-* Refresh connector tooling baseline
+* Validate values before interpolating them into PAN-OS XPath expressions

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Refresh connector tooling baseline

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Validate values before interpolating them into PAN-OS XPath expressions
 * Reject oversized XML replies and documents containing DTD declarations
+* Escape URL and application values embedded in configuration XML

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Validate values before interpolating them into PAN-OS XPath expressions
+* Reject oversized XML replies and documents containing DTD declarations

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 * Validate values before interpolating them into PAN-OS XPath expressions
 * Reject oversized XML replies and documents containing DTD declarations
 * Escape URL and application values embedded in configuration XML
+* Bound commit polling and fail actions when commit jobs fail


### PR DESCRIPTION
### Bug Fixes

- Validate IP, URL, application, and virtual-system values before XPath interpolation.
- Reject oversized XML replies and DTD-bearing documents before parsing.
- Escape URL and application values embedded in configuration XML.
- Bound commit polling and fail actions when status polling or the commit job fails.

Tracks ESPM-5228 and PAPP-37989. Addresses PSAAS-30615, PSAAS-31935, PSAAS-32016, PSAAS-32069, PSAAS-32105, and PSAAS-32373.

PSAAS-31688 is intentionally excluded under the read-only mutation-proof policy because `list applications` only reads configured-firewall data and the report proves neither third-party mutation nor a SOAR vault write. No Jira labels were changed.

Validation: `pre-commit run --all-files`, Python compilation, JSON parsing, `git diff --check`, and signed-commit verification.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate. No manual documentation changes are required.

### Other information

The supplied patches were treated as recommendations and adapted into four distinct connector-owned fixes.

Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!